### PR TITLE
Add internal Schema; prepare for formats other than avro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,23 +2,26 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Install protoc
-      run: sudo apt install protobuf-compiler
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt install protobuf-compiler
+      - name: Rustfmt
+        run: |
+          rustup component add rustfmt
+          cargo fmt --all -- --check
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mstream"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Simon Makarski"]
 
@@ -10,7 +10,7 @@ authors = ["Simon Makarski"]
 mongodb = "2.8.2"
 apache-avro = "0.14"
 anyhow = "1"
-tonic = { version = "0.13", features = ["tls-ring", "tls-native-roots"] }
+tonic = { version = "0.13", features = ["tls-ring", "tls-webpki-roots"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "signal"] }
 toml = "0.8.20"
 serde = "1"

--- a/README.md
+++ b/README.md
@@ -53,25 +53,73 @@ graph TB
 
 mstream supports multiple encoding formats for both sources and sinks:
 
-#### BSON Source:
+#### BSON Source
+
 - BSON → Avro: Converts MongoDB BSON documents to Avro records
 - BSON → JSON: Serializes BSON documents to JSON format
 - BSON → BSON: Direct passthrough (for MongoDB to MongoDB replication)
 
-#### Avro Source:
-- Avro → Avro: Passthrough or schema validation
+#### Avro Source
+
+- Avro → Avro: Passthrough, no schema validation
 - Avro → JSON: Deserializes Avro records to JSON format
 - Avro → BSON: Converts Avro records to MongoDB BSON documents
 
-#### JSON Source:
-- JSON → JSON: Passthrough or format validation
+#### JSON Source
+
+- JSON → JSON: Passthrough
 - JSON → Avro: Parses JSON and encodes as Avro records
 - JSON → BSON: Parses JSON and converts to BSON documents
 
 JSON source operations are processed by first converting to BSON internally and then
 applying the same transformation logic as BSON sources, unless the target is JSON.
 
-### Event Processing
+### Schema Filtering
+
+A schema can be used as a mask to filter out unwanted fields from the source document, allowing you to selectively extract only the data you need.
+
+#### How Schema Filtering Works
+
+When a schema is applied to a source document, only fields defined in the schema will be included in the resulting document. Any fields in the source document that aren't specified in the schema will be excluded.
+
+#### Example
+
+**Schema definition:**
+```json
+{
+  "type": "record",
+  "name": "User",
+  "fields": [
+    { "name": "name", "type": "string" }
+  ]
+}
+```
+
+**Source document:**
+```json
+{
+  "name": "John",
+  "age": 30,
+  "last_name": "Doe"
+}
+```
+
+**Result after filtering:**
+```json
+{
+  "name": "John"
+}
+```
+
+In this example, only the "name" field was included in the result because it was the only field defined in the schema. The "age" and "last_name" fields were filtered out.
+
+#### Schema Resolution
+
+The schema resolution process works by matching the encoding specified in either the source or sink configuration. This determines which schema is used for filtering and how fields are mapped between different schema versions.
+
+You can configure schema resolution in your source or sink settings to control exactly how documents are filtered during processing.
+
+### Mongo Event Processing
 
 **Supported Sources**
 * [MongoDB Change Stream Events](https://www.mongodb.com/docs/v6.0/reference/change-events/)

--- a/mstream-config.toml.example
+++ b/mstream-config.toml.example
@@ -29,6 +29,7 @@ provider = "mongodb"
 name = "mongodb-source"
 connection_string = "mongodb://localhost:27017"
 db_name = "example_db"
+schema_collection = "test_schemas" # Optional: collection to store Avro schemas
 
 # Connector Configurations
 [[connectors]]
@@ -57,7 +58,7 @@ sinks = [
 name = "pubsub-source-connector"
 # Configure PubSub as a source
 source = { service_name = "pubsub-example", id = "projects/your-project/subscriptions/example-subscription", encoding = "avro" }
-schema = { service_name = "pubsub-example", id = "projects/your-project/schemas/pubsub-source-schema", encoding = "avro" }
+schema = { service_name = "mongodb-source", id = "example-id", encoding = "avro" }
 sinks = [
     { service_name = "kafka-cloud", id = "pubsub_data_topic", encoding = "avro" },
     { service_name = "kafka-local", id = "pubsub_data_local", encoding = "json" },

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct Config {
@@ -23,6 +23,12 @@ impl Config {
             .iter()
             .any(|s| matches!(s, Service::MongoDb { .. }))
     }
+
+    pub fn has_pubsub(&self) -> bool {
+        self.services
+            .iter()
+            .any(|s| matches!(s, Service::PubSub { .. }))
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -42,6 +48,7 @@ pub enum Service {
         name: String,
         connection_string: String,
         db_name: String,
+        schema_collection: Option<String>,
     },
 }
 
@@ -111,7 +118,7 @@ pub struct ServiceConfigReference {
     pub encoding: Encoding,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Encoding {
     Avro,

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -1,13 +1,10 @@
-use anyhow::Context;
 use log::debug;
-use mongodb::bson::{self, Document};
-use serde_json::Value;
+use mongodb::bson::Document;
 
 pub mod avro;
 
 pub fn json_to_bson_doc(payload: &[u8]) -> anyhow::Result<Document> {
-    let json_val: Value = serde_json::from_slice(payload).context("failed to parse json")?;
-    debug!("deserialized json value: {}", json_val);
-    let doc = bson::to_document(&json_val).context("failed to convert json to bson")?;
-    Ok(doc)
+    let v: Document = serde_json::from_slice(payload)?;
+    debug!("deserialized json value: {}", v);
+    Ok(v)
 }

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -12,7 +12,7 @@ pub mod api {
 }
 pub mod srvc;
 
-const ENDPOINT: &str = "https://pubsub.googleapis.com";
+const ENDPOINT: &str = "https://pubsub.googleapis.com:443";
 pub const SCOPES: [&str; 1] = ["https://www.googleapis.com/auth/pubsub"];
 
 #[derive(Clone)]
@@ -78,7 +78,9 @@ impl GCPTokenProvider for StaticAccessToken {
 }
 
 pub async fn tls_transport() -> anyhow::Result<Channel> {
-    let tls_config = ClientTlsConfig::new().with_native_roots();
+    let tls_config = ClientTlsConfig::new()
+        .with_enabled_roots()
+        .domain_name("pubsub.googleapis.com");
 
     match Channel::from_static(ENDPOINT)
         .tls_config(tls_config)?

--- a/src/sink/encoding.rs
+++ b/src/sink/encoding.rs
@@ -11,12 +11,12 @@
 //! - BSON → BSON: Passthrough for MongoDB persistence (using Document type)
 //!
 //! ### Avro Source
-//! - Avro → Avro: Passthrough or schema validation
+//! - Avro → Avro: Passthrough, no schema validation
 //! - Avro → JSON: Deserializes Avro records to JSON format
 //! - Avro → BSON: Converts Avro records to MongoDB BSON documents
 //!
 //! ### JSON Source
-//! - JSON → JSON: Passthrough or format validation
+//! - JSON → JSON: Passthrough
 //! - JSON → Avro: Parses JSON and encodes as Avro records
 //! - JSON → BSON: Parses JSON and converts to BSON documents
 //!
@@ -25,13 +25,13 @@
 //! format is JSON itself.
 use std::collections::HashMap;
 
-use anyhow::bail;
-use apache_avro::Schema;
+use anyhow::{anyhow, bail};
 use mongodb::bson::Document;
 
 use crate::{
     config::{Encoding, ServiceConfigReference},
     encoding::{avro, json_to_bson_doc},
+    schema::Schema,
     source::SourceEvent,
 };
 
@@ -46,27 +46,15 @@ impl SinkEvent {
     pub fn from_source_event(
         se: SourceEvent,
         sink_cfg: &ServiceConfigReference,
-        schema: &Schema, // todo: change in future to support different schemas
+        schema: &Schema,
     ) -> anyhow::Result<Self> {
-        match (se.encoding, sink_cfg.encoding.clone()) {
+        match (se.encoding.clone(), sink_cfg.encoding.clone()) {
             (Encoding::Bson, Encoding::Bson) => Ok(Self {
                 bson_doc: se.document,
                 raw_bytes: se.raw_bytes,
                 attributes: se.attributes,
                 encoding: Encoding::Bson,
             }),
-            (Encoding::Bson, Encoding::Avro) => match se.document {
-                Some(doc) => {
-                    let encoded = avro::encode(doc, schema)?;
-                    Ok(Self {
-                        bson_doc: None,
-                        raw_bytes: Some(encoded),
-                        attributes: se.attributes,
-                        encoding: Encoding::Avro,
-                    })
-                }
-                None => bail!("source event document is missing: {:?}", se.attributes),
-            },
             (Encoding::Bson, Encoding::Json) => match se.document {
                 Some(doc) => {
                     let encoded = serde_json::to_vec(&doc)?;
@@ -79,6 +67,39 @@ impl SinkEvent {
                 }
                 None => bail!("source event document is missing: {:?}", se.attributes),
             },
+            (Encoding::Bson | Encoding::Json, Encoding::Avro) => {
+                let avro_schema = schema.as_avro().ok_or_else(|| {
+                    anyhow!(
+                        "failed to retrieve underlying avro schema while converting into avro: {}",
+                        sink_cfg.id
+                    )
+                })?;
+
+                if se.encoding == Encoding::Bson {
+                    let doc = se.document.ok_or_else(|| {
+                        anyhow!("source event document is missing: {:?}", se.attributes)
+                    })?;
+                    let encoded = avro::encode(doc, avro_schema)?;
+                    Ok(Self {
+                        bson_doc: None,
+                        raw_bytes: Some(encoded),
+                        attributes: se.attributes,
+                        encoding: Encoding::Avro,
+                    })
+                } else {
+                    let b = se.raw_bytes.ok_or_else(|| {
+                        anyhow!("source event raw bytes are missing: {:?}", se.attributes)
+                    })?;
+                    let decoded = json_to_bson_doc(&b)?;
+                    let encoded = avro::encode(decoded, avro_schema)?;
+                    Ok(Self {
+                        bson_doc: None,
+                        raw_bytes: Some(encoded),
+                        attributes: se.attributes,
+                        encoding: Encoding::Avro,
+                    })
+                }
+            }
             (Encoding::Avro, Encoding::Avro) => {
                 if se.raw_bytes.is_some() {
                     Ok(Self {
@@ -91,22 +112,29 @@ impl SinkEvent {
                     bail!("source event raw bytes are missing: {:?}", se.attributes)
                 }
             }
-            (Encoding::Avro, Encoding::Bson) => match se.raw_bytes {
-                Some(b) => {
-                    let decoded = avro::decode(&b, schema)?;
+            (Encoding::Avro, Encoding::Bson | Encoding::Json) => {
+                let b = se.raw_bytes.ok_or_else(|| {
+                    anyhow!("source event raw bytes are missing: {:?}", se.attributes)
+                })?;
+
+                let avro_schema = schema.as_avro().ok_or_else(|| {
+                    anyhow!(
+                        "failed to retrieve underlying avro schema while converting from avro: {}",
+                        sink_cfg.id
+                    )
+                })?;
+
+                if sink_cfg.encoding == Encoding::Bson {
+                    let decoded = avro::decode(&b, avro_schema)?;
                     Ok(Self {
                         bson_doc: Some(decoded),
                         raw_bytes: None,
                         attributes: se.attributes,
                         encoding: Encoding::Bson,
                     })
-                }
-                None => bail!("source event raw bytes are missing: {:?}", se.attributes),
-            },
-            (Encoding::Avro, Encoding::Json) => match se.raw_bytes {
-                Some(b) => {
-                    // todo: refactor - avoid decoding to bson and then encoding to json
-                    let decoded = avro::decode(&b, schema)?;
+                } else {
+                    // todo: check if there is a performance hit by decoding to bson and then encoding to json
+                    let decoded = avro::decode(&b, avro_schema)?;
                     let encoded = serde_json::to_vec(&decoded)?;
                     Ok(Self {
                         bson_doc: None,
@@ -115,8 +143,7 @@ impl SinkEvent {
                         encoding: Encoding::Json,
                     })
                 }
-                None => bail!("source event raw bytes are missing: {:?}", se.attributes),
-            },
+            }
             (Encoding::Json, Encoding::Json) => match se.raw_bytes {
                 Some(ref b) => Ok(Self {
                     bson_doc: None,
@@ -134,19 +161,6 @@ impl SinkEvent {
                         raw_bytes: None,
                         attributes: se.attributes,
                         encoding: Encoding::Bson,
-                    })
-                }
-                None => bail!("source event raw bytes are missing: {:?}", se.attributes),
-            },
-            (Encoding::Json, Encoding::Avro) => match se.raw_bytes {
-                Some(b) => {
-                    let bson_doc = json_to_bson_doc(&b)?;
-                    let encoded = avro::encode(bson_doc, schema)?;
-                    Ok(Self {
-                        bson_doc: None,
-                        raw_bytes: Some(encoded),
-                        attributes: se.attributes,
-                        encoding: Encoding::Avro,
                     })
                 }
                 None => bail!("source event raw bytes are missing: {:?}", se.attributes),

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -46,6 +46,7 @@ pub async fn start_app_listener(done_ch: mpsc::Sender<String>) {
                     name: "mongodb".to_owned(),
                     connection_string: DB_CONNECTION.to_owned(),
                     db_name: DB_NAME.to_owned(),
+                    schema_collection: None,
                 },
             ],
             connectors: vec![Connector {


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and configuration of the project, particularly focusing on schema handling, PubSub integration, and code refactoring.

### Schema Handling Improvements:
* Added schema collection configuration for MongoDB sources in `mstream-config.toml.example` to store Avro schemas.
* Introduced a new `Schema` enum to handle different schema types and added methods for parsing and accessing Avro schemas in `src/schema/mod.rs`.

### PubSub Integration Enhancements:
* Implemented GCP token provider caching for PubSub services in `src/cmd/services.rs` to improve performance and reliability.
* Updated PubSub schema handling to support Avro and properly handle unsupported schema types in `src/pubsub/srvc/mod.rs`.

### Code Refactoring:
* Simplified JSON to BSON conversion by removing unnecessary context handling in `src/encoding/mod.rs`.
* Added serialization support to the `Config` struct and the `Encoding` enum in `src/config.rs`. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL3-R3) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL114-R121)

### Configuration Updates:
* Updated `Cargo.toml` to version 0.10.0 and modified dependencies to use `tls-webpki-roots` for `tonic`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L13-R13)
* Added Rustfmt step to the GitHub Actions workflow in `.github/workflows/rust.yml` for code formatting checks.

### Documentation Enhancements:
* Improved the `README.md` with detailed explanations on schema filtering and updated the structure for better readability.