### PR TITLE
Introduce kafka source offset by timestamp config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mstream"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Simon Makarski"]
 

--- a/mstream-config.toml.example
+++ b/mstream-config.toml.example
@@ -16,6 +16,7 @@ name = "kafka-local"
 [[services]]
 provider = "kafka"
 name = "kafka-cloud"
+offset_seek_back_seconds = 3600 # Optional: Seek back 1h in time for Kafka source
 "bootstrap.servers" = "your-kafka-broker:9092"
 "security.protocol" = "SASL_SSL"
 "sasl.mechanism" = "PLAIN"

--- a/src/cmd/services.rs
+++ b/src/cmd/services.rs
@@ -173,9 +173,18 @@ impl<'a> ServiceFactory<'a> {
                     name
                 ),
             },
-            Service::Kafka { config, .. } => {
-                let consumer =
-                    KafkaConsumer::new(&config, sink_cfg.id.clone(), sink_cfg.encoding.clone())?;
+            Service::Kafka {
+                config,
+                offset_seek_back_seconds,
+                ..
+            } => {
+                let consumer = KafkaConsumer::new(
+                    &config,
+                    sink_cfg.id.clone(),
+                    sink_cfg.encoding.clone(),
+                    offset_seek_back_seconds,
+                )?;
+
                 Ok(SourceProvider::Kafka(consumer))
             }
             Service::PubSub { name, .. } => match self.gcp_token_providers.get(&name) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub enum Service {
     #[serde(rename = "kafka")]
     Kafka {
         name: String,
+        offset_seek_back_seconds: Option<u64>,
         #[serde(flatten)]
         #[serde(deserialize_with = "deserialize_hasmap_with_env_vals")]
         config: HashMap<String, String>,

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::Context;
+use anyhow::{anyhow, bail, Context, Ok};
 use async_trait::async_trait;
 use log::{debug, info};
-use rdkafka::consumer::stream_consumer::StreamConsumer;
-use rdkafka::consumer::Consumer;
-use rdkafka::{ClientConfig, Message};
+use rdkafka::consumer::{stream_consumer::StreamConsumer, Consumer};
+use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
 use tokio::sync::mpsc::Sender;
 
 use crate::config::Encoding;
@@ -15,6 +15,7 @@ pub struct KafkaConsumer {
     consumer: StreamConsumer,
     topic: String,
     encoding: Encoding,
+    start_timestamp_ms: Option<u128>,
 }
 
 impl KafkaConsumer {
@@ -22,6 +23,7 @@ impl KafkaConsumer {
         configs: &HashMap<String, String>,
         topic: String,
         encoding: Encoding,
+        seek_back_secs: Option<u64>,
     ) -> anyhow::Result<Self> {
         debug!("kafka consumer configs: {:?}", configs);
         let mut cfg = ClientConfig::new();
@@ -31,17 +33,127 @@ impl KafkaConsumer {
         });
 
         let consumer: StreamConsumer = cfg.create().context("kafka consumer creation failed")?;
+
+        let start_timestamp = match seek_back_secs {
+            Some(seconds) => {
+                let duration = Duration::from_secs(seconds);
+                let start_time = SystemTime::now() - duration;
+                let start_timestamp = start_time
+                    .duration_since(UNIX_EPOCH)
+                    .context("failed to get duration since epoch")?
+                    .as_millis();
+                Some(start_timestamp)
+            }
+            None => None,
+        };
+
         Ok(Self {
             consumer,
             topic,
             encoding,
+            start_timestamp_ms: start_timestamp,
         })
+    }
+
+    fn seek_to_timestamp(&self) -> anyhow::Result<()> {
+        if let Some(start_ts) = self.start_timestamp_ms {
+            info!("seeking to timestamp: {}. {}", start_ts, self.topic);
+
+            let timeout = Duration::from_secs(10);
+            let metadata = self
+                .consumer
+                .fetch_metadata(Some(&self.topic), timeout)
+                .with_context(|| anyhow!("failed to fetch topic metadata: {}", self.topic))?;
+
+            let topic_metadata = metadata
+                .topics()
+                .iter()
+                .find(|t| t.name() == self.topic)
+                .ok_or_else(|| anyhow!("topic not found: {}", self.topic))?;
+
+            let partitions = topic_metadata.partitions();
+            let mut topic_partitions = TopicPartitionList::new();
+
+            let offset = Offset::Offset(start_ts as i64);
+            for partition in partitions {
+                let partition_id = partition.id();
+                topic_partitions.add_partition_offset(&self.topic, partition_id, offset)?;
+            }
+
+            let offsets_for_times = self.consumer.offsets_for_times(topic_partitions, timeout)?;
+            let mut seek_tpl = TopicPartitionList::new();
+
+            for partition in offsets_for_times.elements() {
+                if let Offset::Offset(offset) = partition.offset() {
+                    if offset > 0 {
+                        seek_tpl.add_partition_offset(
+                            partition.topic(),
+                            partition.partition(),
+                            Offset::Offset(offset),
+                        )?;
+
+                        debug!(
+                            "topic: {}. added offset for partition: {}. offset: {}",
+                            partition.topic(),
+                            partition.partition(),
+                            offset
+                        );
+                    } else {
+                        // handle a case when no valid offset is returned
+                        // kafka returns -1001 for no offset
+                        // so we need to get the high watermark, ie latest offset
+                        let watermarks = self.consumer.fetch_watermarks(
+                            partition.topic(),
+                            partition.partition(),
+                            timeout,
+                        )?;
+
+                        seek_tpl.add_partition_offset(
+                            partition.topic(),
+                            partition.partition(),
+                            Offset::Offset(watermarks.1), // high watermark
+                        )?;
+
+                        debug!(
+                            "topic: {}. added high watermark for partition: {}. offset: {}",
+                            partition.topic(),
+                            partition.partition(),
+                            watermarks.1
+                        );
+                    }
+                } else {
+                    bail!("invalid offset type");
+                }
+            }
+
+            debug!(
+                "topic: {}. seek to timestamp: {}. partitions: {:?}",
+                self.topic,
+                start_ts,
+                seek_tpl.elements().len(),
+            );
+
+            if !seek_tpl.elements().is_empty() {
+                debug!("assigning topic partitions: {:?}", seek_tpl);
+
+                self.consumer
+                    .assign(&seek_tpl)
+                    .context("failed to assign topic partitions")?;
+            }
+        } else {
+            info!("no start timestamp provided.");
+        }
+
+        Ok(())
     }
 }
 
 #[async_trait]
 impl EventSource for KafkaConsumer {
     async fn listen(&mut self, events: Sender<SourceEvent>) -> anyhow::Result<()> {
+        self.seek_to_timestamp()
+            .context("failed to seek to timestamp")?;
+
         self.consumer.subscribe(&[&self.topic])?;
         info!("subscribed to topic: {}", self.topic);
 


### PR DESCRIPTION
Resolves #27 

This pull request introduces a new feature to seek back in time for Kafka sources and includes several changes to support this functionality. The most important changes include updating the version number, modifying the Kafka service configuration, and adding the logic to handle seeking to a specific timestamp in the Kafka consumer.

### Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the version from `0.10.0` to `0.11.0`.

### Configuration changes:

* [`mstream-config.toml.example`](diffhunk://#diff-d1bc32a394a2914bf851448c8b8f5afd5e3e4769cbd9d97d17e359ebf4d03f74R19): Added the `offset_seek_back_seconds` parameter to the Kafka service configuration to specify the number of seconds to seek back in time.

### Kafka consumer changes:

* [`src/config.rs`](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR42): Updated the `Service` enum to include the `offset_seek_back_seconds` field for the Kafka service.
* [`src/cmd/services.rs`](diffhunk://#diff-29b98499dd9d9544e63c040b97f18cbf5c1581aa5d449743359f97d24b9f0bdaL176-R187): Modified the `ServiceFactory` implementation to pass the `offset_seek_back_seconds` parameter to the `KafkaConsumer` constructor.
* [`src/kafka/consumer.rs`](diffhunk://#diff-eec920d37f81878e4ab158e5d2a5c78e067b2beefbbf0353b501bae1655a6600R2-R8): Added the logic to handle seeking to a specific timestamp in the `KafkaConsumer` class, including the `seek_to_timestamp` method and the necessary imports. [[1]](diffhunk://#diff-eec920d37f81878e4ab158e5d2a5c78e067b2beefbbf0353b501bae1655a6600R2-R8) [[2]](diffhunk://#diff-eec920d37f81878e4ab158e5d2a5c78e067b2beefbbf0353b501bae1655a6600R18-R26) [[3]](diffhunk://#diff-eec920d37f81878e4ab158e5d2a5c78e067b2beefbbf0353b501bae1655a6600R36-R156)