### PR TITLE
Add Web Server sink support: HTTP POST

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mstream"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Simon Makarski"]
 
@@ -25,10 +25,14 @@ prost-types = "0.13"
 rdkafka = { version = "0.37", features = ["ssl"] }
 futures = "0.3.31"
 tokio-stream = "0.1.17"
+reqwest = "0.12.15"
+rand = "0.9.0"
+thiserror = "2.0.12"
 
 [build-dependencies]
 tonic-build = "0.13"
 prost-derive = "0.13"
 
 [dev-dependencies]
+mockito = "1.7.0"
 apache-avro = { version = "0.14", features = ["derive"] }

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Simon Makarski
+Copyright (c) 2025 Simon Makarski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mstream-config.toml.example
+++ b/mstream-config.toml.example
@@ -32,6 +32,16 @@ connection_string = "mongodb://localhost:27017"
 db_name = "example_db"
 schema_collection = "test_schemas" # Optional: collection to store Avro schemas
 
+[[services]]
+provider = "http"
+name = "http-local"
+url = "http://localhost:8000/rustest"
+max_retries = 5 # Optional: default is 5
+base_backoff_ms = 1000 # Optional: default is 1000ms
+connection_timeout_sec = 30
+timeout_sec = 30 # Optional: default is 30 seconds
+tcp_keepalive_sec = 300 # Optional: default is 300 seconds
+
 # Connector Configurations
 [[connectors]]
 name = "mongodb-source-connector"
@@ -44,6 +54,7 @@ sinks = [
     { service_name = "kafka-cloud", id = "cloud_topic", encoding = "avro" },
     { service_name = "pubsub-example", id = "projects/your-project/topics/example-topic", encoding = "avro" },
     { service_name = "mongodb-source", id = "example_collection_copy", encoding = "bson" },
+    { service_name = "http-local", id = "http_sink", encoding = "json" }
 ]
 
 [[connectors]]

--- a/src/cmd/event_handler.rs
+++ b/src/cmd/event_handler.rs
@@ -9,7 +9,6 @@ use crate::{
     source::SourceEvent,
 };
 
-// rename to event handler - do event processing here
 pub struct EventHandler {
     pub connector_name: String,
     pub schema_provider: Option<(String, SchemaProvider)>,
@@ -17,7 +16,7 @@ pub struct EventHandler {
 }
 
 impl EventHandler {
-    /// Listen to a mongodb change stream and publish the events to the configured sinks
+    /// Listen to source streams and publish the events to the configured sinks
     pub async fn listen(&mut self, mut events_rx: Receiver<SourceEvent>) -> anyhow::Result<()> {
         loop {
             match events_rx.recv().await {
@@ -57,8 +56,8 @@ impl EventHandler {
                 .await?;
 
             info!(
-                "successfully published a message: {:?}. stream: {}. id: {}",
-                message, &self.connector_name, sink_cfg.id,
+                "published a message to: {}:{:?}. stream: {}. id: {}",
+                sink_cfg.service_name, message, &self.connector_name, sink_cfg.id,
             );
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,16 @@ pub enum Service {
         db_name: String,
         schema_collection: Option<String>,
     },
+    #[serde(rename = "http")]
+    Http {
+        name: String,
+        url: String,
+        max_retries: Option<u32>,
+        base_backoff_ms: Option<u64>,
+        connection_timeout_sec: Option<u64>,
+        timeout_sec: Option<u64>,
+        tcp_keepalive_sec: Option<u64>,
+    },
 }
 
 fn deserialize_hasmap_with_env_vals<'de, D>(
@@ -89,6 +99,7 @@ impl Service {
             Service::PubSub { name, .. } => name.as_str(),
             Service::Kafka { name, .. } => name.as_str(),
             Service::MongoDb { name, .. } => name.as_str(),
+            Service::Http { name, .. } => name.as_str(),
         }
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,541 @@
+use std::collections::HashMap;
+
+use anyhow::bail;
+use log::warn;
+use rand::Rng;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use thiserror::Error;
+use tokio::time::{sleep, Duration};
+
+use crate::{config::Encoding, sink::encoding::SinkEvent};
+
+pub struct HttpService {
+    url: String,
+    client: reqwest::Client,
+    max_retries: u32,
+    base_backoff_ms: u64,
+}
+
+#[derive(Error, Debug)]
+#[error("failed to send request: {source}")]
+struct ResponseError {
+    source: reqwest::Error,
+    should_retry: bool,
+}
+
+impl HttpService {
+    pub fn new(
+        url: String,
+        max_retries: Option<u32>,
+        base_backoff_ms: Option<u64>,
+        connection_timeout_sec: Option<u64>,
+        timeout_sec: Option<u64>,
+        tcp_keepalive_sec: Option<u64>,
+    ) -> anyhow::Result<HttpService> {
+        let tcp_keepalive = tcp_keepalive_sec
+            .map(Duration::from_secs)
+            .or_else(|| Some(Duration::from_secs(300)));
+
+        let connection_timeout = connection_timeout_sec
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| Duration::from_secs(10));
+
+        let timeout = timeout_sec
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| Duration::from_secs(30));
+
+        let max_retries = max_retries.unwrap_or(5);
+        let base_backoff_ms = base_backoff_ms.unwrap_or(1000);
+
+        let client = reqwest::Client::builder()
+            .tcp_keepalive(tcp_keepalive)
+            .connect_timeout(connection_timeout)
+            .timeout(timeout)
+            .build()?;
+
+        Ok(HttpService {
+            url,
+            client,
+            max_retries,
+            base_backoff_ms,
+        })
+    }
+
+    pub async fn publish(&mut self, event: SinkEvent) -> anyhow::Result<String> {
+        let payload = match event.raw_bytes {
+            Some(b) => b,
+            None => {
+                bail!(
+                    "raw_bytes is missing for http sink. url: {}. encoding: {:?}",
+                    self.url,
+                    event.encoding
+                )
+            }
+        };
+
+        let headers = self.headers_from_attrs(event.attributes, event.encoding)?;
+
+        let mut attempt = 0;
+        let mut last_error = None;
+        while attempt < self.max_retries {
+            attempt += 1;
+            match self.execute_req(payload.clone(), headers.clone()).await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let should_retry = err.should_retry;
+                    warn!(
+                        "http sink: failed to publish event. url: {}. attempt: {}. error: {}",
+                        self.url, attempt, err
+                    );
+                    last_error = Some(err);
+                    if !should_retry {
+                        break;
+                    }
+
+                    if attempt < self.max_retries {
+                        let backoff = self.calculate_backoff(attempt);
+                        sleep(Duration::from_millis(backoff)).await;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        let err_msg = match last_error {
+            Some(err) => format!("{}", err),
+            None => "unknown error".to_owned(),
+        };
+
+        bail!(
+            "failed to publish event after {} attempts: {}",
+            attempt,
+            err_msg
+        )
+    }
+
+    async fn execute_req(
+        &self,
+        payload: Vec<u8>,
+        headers: HeaderMap,
+    ) -> Result<String, ResponseError> {
+        let response = self
+            .client
+            .post(&self.url)
+            .headers(headers)
+            .body(payload)
+            .send()
+            .await
+            .map_err(|err| ResponseError {
+                source: err,
+                should_retry: true,
+            })?;
+
+        let response_status = response.status();
+        match response.error_for_status() {
+            Ok(response) => Ok(response.text().await.map_err(|err| ResponseError {
+                source: err,
+                should_retry: true,
+            })?),
+            Err(err) => {
+                let should_retry = self.is_status_retriable(response_status);
+                let err = ResponseError {
+                    source: err,
+                    should_retry,
+                };
+                Err(err)
+            }
+        }
+    }
+
+    fn is_status_retriable(&self, status: reqwest::StatusCode) -> bool {
+        // Server errors (5xx) are generally retriable
+        if status.is_server_error() {
+            return true;
+        }
+
+        // Special cases of client errors that may be retriable
+        match status.as_u16() {
+            // Too Many Requests - should retry after respecting Retry-After header
+            429 => true,
+
+            // Specific 4xx codes that might be temporary conditions
+            408 => true, // Request Timeout
+            423 => true, // Locked (WebDAV) - resource is temporarily locked
+            425 => true, // Too Early - server is unwilling to risk processing a request that might be replayed
+
+            // All other client errors (4xx) are not retriable
+            _ => false,
+        }
+    }
+
+    fn calculate_backoff(&self, attempt: u32) -> u64 {
+        let base = self.base_backoff_ms;
+
+        // shift by max 16 bits to avoid overflow
+        let exp_backoff = base * (1 << attempt.min(16));
+
+        // +/- 20%
+        let jitter_factor = rand::rng().random_range(0.8..1.2);
+        let backoff = exp_backoff as f64 * jitter_factor;
+
+        backoff as u64
+    }
+
+    fn headers_from_attrs(
+        &self,
+        attr: Option<HashMap<String, String>>,
+        encoding: Encoding,
+    ) -> anyhow::Result<HeaderMap> {
+        let mut hmap = HeaderMap::new();
+        let _ = match encoding {
+            Encoding::Avro => hmap.insert(
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_str("avro/binary")?,
+            ),
+            Encoding::Json => hmap.insert(
+                HeaderName::from_static("content-type"),
+                HeaderValue::from_str("application/json")?,
+            ),
+            _ => bail!("unsupported encoding: {:?}", encoding),
+        };
+
+        if let Some(attr) = attr {
+            for (name, value) in attr {
+                let custom_name = format!("X-{}", name);
+                let header_name = custom_name.parse::<HeaderName>()?;
+                let val = value.parse::<HeaderValue>()?;
+                hmap.insert(header_name, val);
+            }
+        }
+
+        Ok(hmap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HttpService;
+    use crate::{config::Encoding, sink::encoding::SinkEvent};
+    use mockito::Server;
+    use std::{
+        collections::HashMap,
+        time::{Duration, Instant},
+    };
+
+    // Helper function to create a SinkEvent for testing
+    fn create_test_event(
+        raw_bytes: Option<Vec<u8>>,
+        attributes: Option<HashMap<String, String>>,
+        encoding: Encoding,
+    ) -> SinkEvent {
+        SinkEvent {
+            raw_bytes,
+            attributes,
+            encoding,
+            bson_doc: None,
+        }
+    }
+
+    #[test]
+    fn test_constructor_default_parameters() {
+        // Test that constructor uses default values correctly
+        let service = HttpService::new(
+            "https://example.com".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(service.url, "https://example.com");
+        assert_eq!(service.max_retries, 5);
+        assert_eq!(service.base_backoff_ms, 1000);
+    }
+
+    #[test]
+    fn test_constructor_custom_parameters() {
+        // Test constructor with custom parameters
+        let service = HttpService::new(
+            "https://example.com".to_string(),
+            Some(10),
+            Some(500),
+            Some(20),
+            Some(60),
+            Some(120),
+        )
+        .unwrap();
+
+        assert_eq!(service.url, "https://example.com");
+        assert_eq!(service.max_retries, 10);
+        assert_eq!(service.base_backoff_ms, 500);
+    }
+
+    #[tokio::test]
+    async fn test_custom_headers_from_attributes() {
+        // Setup mock to verify custom headers
+        let mut server = Server::new_async().await;
+        let mock_server = server
+            .mock("POST", "/webhook")
+            .match_header("X-CustomHeader", "custom-value")
+            .match_header("X-ApiKey", "secret-key")
+            .with_status(200)
+            .with_body("ok")
+            .create();
+
+        // Create HttpSink
+        let mut sink = HttpService::new(
+            format!("{}/webhook", server.url()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Create test event with custom headers
+        let payload = r#"{"test":"data"}"#.as_bytes().to_vec();
+        let mut attributes = HashMap::new();
+        attributes.insert("CustomHeader".to_string(), "custom-value".to_string());
+        attributes.insert("ApiKey".to_string(), "secret-key".to_string());
+        let event = create_test_event(Some(payload), Some(attributes), Encoding::Json);
+
+        // Call publish
+        let _ = sink.publish(event).await;
+
+        // Verify headers were sent correctly
+        mock_server.assert();
+    }
+
+    #[tokio::test]
+    async fn test_retry_for_specific_status_codes() {
+        let mut server = Server::new_async().await;
+
+        // Test retry behavior for specific status codes
+        for status in [429, 408, 423, 425, 500, 502, 503, 504] {
+            // Setup mocks: first attempt fails with status code, second succeeds
+            let _mock_fail = server.mock("POST", "/webhook").with_status(status).create();
+
+            let mock_success = server
+                .mock("POST", "/webhook")
+                .with_status(200)
+                .with_body("ok")
+                .create();
+
+            // Create HttpSink with fast retries for testing
+            let mut sink = HttpService::new(
+                format!("{}/webhook", server.url()),
+                Some(3),
+                Some(10),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+            // Create test event
+            let payload = r#"{"test":"data"}"#.as_bytes().to_vec();
+            let event = create_test_event(Some(payload), None, Encoding::Json);
+
+            // Call publish method
+            let result = sink.publish(event).await;
+
+            // Verify success after retry
+            assert!(result.is_ok());
+            mock_success.assert();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_no_retry_for_client_errors() {
+        let mut server = Server::new_async().await;
+
+        // Test no retry for most client errors (except specific ones like 429)
+        for status in [400, 401, 403, 404, 405, 409, 422] {
+            // Setup mock with client error - should only be called once
+            let mock_error = server
+                .mock("POST", "/webhook")
+                .with_status(status)
+                .expect(1)
+                .create();
+
+            // Create HttpSink with multiple retries that shouldn't be used
+            let mut sink = HttpService::new(
+                format!("{}/webhook", server.url()),
+                Some(3),
+                Some(10),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+            // Create test event
+            let payload = r#"{"test":"data"}"#.as_bytes().to_vec();
+            let event = create_test_event(Some(payload), None, Encoding::Json);
+
+            // Call publish method
+            let result = sink.publish(event).await;
+
+            // Verify failure without retry
+            assert!(result.is_err());
+            mock_error.assert();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_encoding() {
+        // Create HttpSink
+        let mut sink = HttpService::new(
+            "https://example.com/webhook".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Use an unsupported encoding (BSON)
+        let payload = vec![1, 2, 3, 4];
+        let event = create_test_event(Some(payload), None, Encoding::Bson);
+
+        // Call publish
+        let result = sink.publish(event).await;
+
+        // Verify error for unsupported encoding
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported encoding"));
+    }
+
+    #[tokio::test]
+    async fn test_backoff_calculation() {
+        let sink = HttpService::new(
+            "https://example.com".to_string(),
+            None,
+            Some(10),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Test backoff values for different attempts
+        // With base_backoff_ms = 10:
+        // Attempt 1: ~10ms (with jitter)
+        // Attempt 2: ~20ms (with jitter)
+        // Attempt 3: ~40ms (with jitter)
+
+        for attempt in 1..=5 {
+            let backoff = sink.calculate_backoff(attempt);
+
+            // Verify backoff is within expected range (allowing for jitter)
+            let expected_base = 10 * (1 << attempt.min(16));
+            assert!(backoff >= (expected_base as f64 * 0.8) as u64);
+            assert!(backoff <= (expected_base as f64 * 1.2) as u64);
+        }
+
+        // Test with a very large attempt number (shouldn't overflow)
+        let backoff = sink.calculate_backoff(100);
+        assert!(backoff > 0);
+    }
+
+    #[tokio::test]
+    async fn test_headers_with_invalid_values() {
+        // Create HttpSink
+        let mut sink = HttpService::new(
+            "https://example.com/webhook".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Create attributes with invalid header value
+        let mut attributes = HashMap::new();
+        attributes.insert("Valid-Header".to_string(), "valid value".to_string());
+        attributes.insert("Invalid-Header".to_string(), "invalid\nvalue".to_string());
+
+        // Create test event
+        let payload = r#"{"test":"data"}"#.as_bytes().to_vec();
+        let event = create_test_event(Some(payload), Some(attributes), Encoding::Json);
+
+        // Call publish
+        let result = sink.publish(event).await;
+
+        // Should fail due to invalid header value
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_gradually_increasing_retry_delays() {
+        let mut server = Server::new_async().await;
+        // Setup mock to fail multiple times
+        let _mock = server
+            .mock("POST", "/webhook")
+            .with_status(500)
+            .expect(3)
+            .create();
+
+        // Create HttpSink with small base backoff for testing
+        let mut sink = HttpService::new(
+            format!("{}/webhook", server.url()),
+            Some(3),
+            Some(20),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Create test event
+        let payload = r#"{"test":"data"}"#.as_bytes().to_vec();
+        let event = create_test_event(Some(payload), None, Encoding::Json);
+
+        // Capture timing of each attempt
+        let start = Instant::now();
+        let _ = sink.publish(event).await;
+        let total_time = start.elapsed();
+
+        // With exponential backoff, total should be at least ~20ms + ~40ms = ~60ms
+        // Need to be generous with the minimum time due to test environment variability
+        assert!(total_time >= Duration::from_millis(40));
+    }
+
+    #[tokio::test]
+    async fn test_retry_behavior_for_network_errors() {
+        // Create HttpSink with an invalid URL to trigger network errors
+        let mut sink = HttpService::new(
+            "https://non-existent-domain-12345.example".to_string(),
+            Some(2),
+            Some(10),
+            Some(1), // 1-second connection timeout
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Create test event
+        let payload = r#"{"test":"data"}"#.as_bytes().to_vec();
+        let event = create_test_event(Some(payload), None, Encoding::Json);
+
+        // Time the operation to verify retries
+        let start = Instant::now();
+        let result = sink.publish(event).await;
+        let elapsed = start.elapsed();
+
+        // Request should fail after retries
+        assert!(result.is_err());
+
+        // With 2 retries and 10ms base backoff, should take at least 20ms
+        // (being conservative due to test environment variability)
+        assert!(elapsed >= Duration::from_millis(20));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use log::{debug, warn};
 use tokio::sync::mpsc;
 
 mod encoding;
+mod http;
 mod kafka;
 mod mongodb;
 mod sink;

--- a/src/sink/encoding.rs
+++ b/src/sink/encoding.rs
@@ -39,7 +39,7 @@ pub struct SinkEvent {
     pub bson_doc: Option<Document>,
     pub raw_bytes: Option<Vec<u8>>,
     pub attributes: Option<HashMap<String, String>>,
-    encoding: Encoding,
+    pub encoding: Encoding,
 }
 
 impl SinkEvent {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use encoding::SinkEvent;
 
 use crate::{
+    http::HttpService,
     kafka::producer::KafkaProducer,
     mongodb::persister::MongoDbPersister,
     pubsub::{srvc::PubSubPublisher, ServiceAccountAuth},
@@ -24,6 +25,7 @@ pub enum SinkProvider {
     Kafka(KafkaProducer),
     PubSub(PubSubPublisher<ServiceAccountAuth>),
     MongoDb(MongoDbPersister),
+    Http(HttpService),
 }
 
 #[async_trait]
@@ -59,6 +61,7 @@ impl EventSink for SinkProvider {
                     topic
                 )),
             },
+            SinkProvider::Http(p) => p.publish(sink_event).await,
         }
     }
 }


### PR DESCRIPTION
Resolves #19 

This pull request includes several updates to the `mstream` project, primarily focusing on adding support for HTTP sinks, updating dependencies, and improving documentation. The most important changes are summarized below:

### New Features:
* Added support for HTTP sinks, including the configuration and initialization of HTTP services (`src/cmd/services.rs`, `src/config.rs`, `src/sink/mod.rs`). [[1]](diffhunk://#diff-29b98499dd9d9544e63c040b97f18cbf5c1581aa5d449743359f97d24b9f0bdaR151-R171) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR54-R63) [[3]](diffhunk://#diff-6bc1ea82f760cd50cfd90c6dde0e35974e71b2e50ca4a5823490625b557f0601R28)

### Dependency Updates:
* Updated the project version to `0.12.0` and added new dependencies: `reqwest`, `rand`, `thiserror`, and `mockito` in `Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R28-R37)

### Documentation Improvements:
* Enhanced the `README.md` to provide more detailed information about supported sources, sinks, and configuration examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R70) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-L173)

### Configuration Changes:
* Updated `mstream-config.toml.example` to include an example configuration for the new HTTP service. [[1]](diffhunk://#diff-d1bc32a394a2914bf851448c8b8f5afd5e3e4769cbd9d97d17e359ebf4d03f74R35-R44) [[2]](diffhunk://#diff-d1bc32a394a2914bf851448c8b8f5afd5e3e4769cbd9d97d17e359ebf4d03f74R57)

### Codebase Enhancements:
* Various improvements and bug fixes, including making `encoding` field public in `SinkEvent` and correcting a typo in `KafkaConsumer`. [[1]](diffhunk://#diff-0cedb4c8e0bdbb0109d1112d5fb7f27b037bd8c6abd2c3b733ca3c0c1c5eaad6L42-R42) [[2]](diffhunk://#diff-eec920d37f81878e4ab158e5d2a5c78e067b2beefbbf0353b501bae1655a6600L103-R103)

These changes enhance the functionality and usability of the `mstream` project, particularly by expanding its capabilities to include HTTP sinks and improving the overall documentation and configuration options.